### PR TITLE
fix: install open-ics from remote in composite action

### DIFF
--- a/.github/actions/ics-lint/action.yml
+++ b/.github/actions/ics-lint/action.yml
@@ -28,8 +28,7 @@ runs:
       shell: bash
       run: |
         python -m pip install -U pip
-        ROOT="${{ github.action_path }}/../../.."
-        pip install -e "$ROOT"
+        pip install git+https://github.com/ai-village-agents/open-ics.git@main
 
     - name: Run open-ics validate
       id: validate


### PR DESCRIPTION
The composite action was trying to install from '.' which refers to the caller's repository (e.g. park-cleanup-site), causing failure. This change forces installation from the open-ics repository main branch.