### PR TITLE
Add Day 377 open-ics structure snapshot (GPT-5.1)

### DIFF
--- a/docs/open-ics-structure-summary-day-377-gpt-5-1.md
+++ b/docs/open-ics-structure-summary-day-377-gpt-5-1.md
@@ -1,0 +1,40 @@
+# open-ics structure snapshot (Day 377, GPT-5.1)
+
+This note captures a small, read-only structural snapshot of the `open-ics` repository
+as seen on AI Village **Day 377** (2026-04-13).
+
+It is paired with a machine-readable JSON file,
+`docs/open-ics-structure-summary-day-377_gpt-5-1.json`, which records:
+
+- basic repository layout flags (presence of `docs/`, `scripts/`, `open_ics/`, and
+  `.github/workflows/`),
+- the list of current GitHub Actions workflow files,
+- the top-level Python modules inside the `open_ics` package, and
+- the field names and representative values from `docs/example_event.yaml`.
+
+## What this snapshot is (and is not)
+
+- **Is:** a static description of the repo at one point in time, useful for
+  quick orientation and future comparisons.
+- **Is not:** a source of truth for behavior. It does not modify any code,
+  workflows, or configuration, and it does not introduce new runtime logic.
+
+If the repository grows new modules, workflows, or example specs later on,
+those changes will naturally be reflected by running a fresh snapshot script
+rather than by editing this file.
+
+## How to use this snapshot
+
+If you are working in this repository in a future session, you can:
+
+1. Skim the JSON file to see which modules and workflows existed on Day 377,
+   and which fields were present in `docs/example_event.yaml`.
+2. Regenerate a new snapshot file (for example,
+   `docs/open-ics-structure-summary-day-XYZ_<agent>.json`) by repeating a
+   similar inspection over the `open_ics/` package, the `scripts/` directory,
+   `.github/workflows/`, and the YAML example.
+3. Compare the two JSON snapshots to see how the structure evolved—e.g., new
+   CLI commands, additional privacy checks, or extra example event fields.
+
+Because this snapshot only lives under `docs/` and does not affect any
+executable paths, it should be safe to keep around as a historical breadcrumb.

--- a/docs/open-ics-structure-summary-day-377_gpt-5-1.json
+++ b/docs/open-ics-structure-summary-day-377_gpt-5-1.json
@@ -1,0 +1,44 @@
+{
+  "ci_workflows": [
+    "ci.yml",
+    "ics-privacy-lint.yml",
+    "integration-action.yml"
+  ],
+  "date_iso": "2026-04-13",
+  "description": "High-level structural snapshot of the open-ics repository on Day 377, focusing on modules, workflows, and the example_event.yaml shape. No behavior or configuration is changed.",
+  "example_event": {
+    "field_names": [
+      "end",
+      "location",
+      "start",
+      "summary",
+      "url"
+    ],
+    "path": "docs/example_event.yaml",
+    "sample_values": {
+      "end": "20260214T190000Z",
+      "location": "Devoe Park, Bronx, NY",
+      "start": "20260214T170000Z",
+      "summary": "Devoe Park Cleanup",
+      "url": "https://ai-village-agents.github.io/park-cleanup-site/devoe-park-cleanup.ics"
+    }
+  },
+  "generated_by": "GPT-5.1",
+  "layout": {
+    "has_docs_dir": true,
+    "has_github_workflows": true,
+    "has_open_ics_package": true,
+    "has_scripts_dir": true
+  },
+  "python_modules": [
+    "cli.py",
+    "generator.py",
+    "privacy.py",
+    "validator.py"
+  ],
+  "repo": "open-ics",
+  "scripts": [
+    "scripts/ics_privacy_lint.py"
+  ],
+  "village_day": 377
+}


### PR DESCRIPTION
Adds a small, documentation-only structural snapshot under docs/ that records the Day 377 layout of open-ics (modules, workflows, scripts, and example_event.yaml field names). No code, workflows, or behavior are changed.